### PR TITLE
Update to use action not handler to use history.put

### DIFF
--- a/src/container/EntranceContainer.jsx
+++ b/src/container/EntranceContainer.jsx
@@ -40,10 +40,6 @@ export default function EntranceContainer({
 }) {
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    dispatch(loadEntrance({ key: postcardKey }));
-  }, []);
-
   const {
     entrance,
     inputFields,
@@ -57,7 +53,18 @@ export default function EntranceContainer({
     postcardCount,
     writtenCount,
     isPrivate,
+    movePage,
   } = entrance;
+
+  useEffect(() => {
+    if (movePage) {
+      onHandleClickPostcard();
+    }
+
+    dispatch(loadEntrance({ key: postcardKey }));
+  }, []);
+
+  
 
   const { entrance: { secretMessage } } = inputFields;
 
@@ -78,7 +85,6 @@ export default function EntranceContainer({
     dispatch(checkValidPostcard({
       key,
       secretMessage: secretMessage.value,
-      onHandleClickPostcard,
     }));
   }
 

--- a/src/container/EntranceContainer.test.jsx
+++ b/src/container/EntranceContainer.test.jsx
@@ -36,105 +36,105 @@ describe('EntranceContainer', () => {
       />
     ));
   }
-
-  it('shows title', () => {
-    const { getByText } = entranceRender();
-
-    expect(getByText(`${sender}님으로 부터 엽서가 도착했어요.`)).not.toBeNull();
-  });
-
-  context('when postcard is private', () => {
+  context('when movePage is true', () => {
     beforeEach(() => {
       useSelector.mockImplementation((selector) => selector({
-        entrance,
+        entrance: {
+          ...entrance,
+          movePage: true,
+        },
         inputFields,
       }));
     });
-
-    it('shows secretMessage form and information', () => {
-      const { getByText, getByPlaceholderText } = entranceRender();
-
-      expect(getByPlaceholderText('5 ~ 20자')).not.toBeNull();
-      expect(getByText('비공개 엽서입니다. 문자로 받은 비밀 메시지를 입력 후 엽서 확인하기 버튼을 눌러주세요.')).not.toBeNull();
-
-      fireEvent.change(getByPlaceholderText('5 ~ 20자'), { target: { value: 'hello' } });
-
-      expect(dispatch).toBeCalledWith({
-        payload: {
-          page: 'entrance',
-          type: 'secretMessage',
-          value: 'hello',
-        },
-        type: 'application/changeInputFieldValue',
-      });
+    it('calls onHandleClickPostcard', () => {
+      entranceRender();
+      expect(onHandleClickPostcard).toBeCalled();
     });
+  });
 
-    context('when clicks check postcard button', () => {
-      context('with secretMessage over 5 and under 21', () => {
-        beforeEach(() => {
-          inputFields.entrance.secretMessage.value = 'happy day!';
-
-          useSelector.mockImplementation((selector) => selector({
-            entrance,
-            inputFields,
-          }));
-        });
-
-        it('calls onHandleClickPostcard function', () => {
-          const { getByText } = entranceRender();
-          expect(getByText('엽서 확인하기')).not.toBeNull();
-
-          fireEvent.click(getByText('엽서 확인하기'));
-
-          // TODO: 공개 || 비공개일 경우 각각 다른 action들이 발생하는 것에 대한 테스트 코드를 작성 해야함.
-          // expect(dispatch).toBeCalledWith({
-          //   type: 'application/',
-          // });
+  context('when movePage is not true', () => {
+    it('shows title', () => {
+      const { getByText } = entranceRender();
+  
+      expect(getByText(`${sender}님으로 부터 엽서가 도착했어요.`)).not.toBeNull();
+    });
+  
+    context('when postcard is private', () => {
+      beforeEach(() => {
+        useSelector.mockImplementation((selector) => selector({
+          entrance,
+          inputFields,
+        }));
+      });
+  
+      it('shows secretMessage form and information', () => {
+        const { getByText, getByPlaceholderText } = entranceRender();
+  
+        expect(getByPlaceholderText('5 ~ 20자')).not.toBeNull();
+        expect(getByText('비공개 엽서입니다. 문자로 받은 비밀 메시지를 입력 후 엽서 확인하기 버튼을 눌러주세요.')).not.toBeNull();
+  
+        fireEvent.change(getByPlaceholderText('5 ~ 20자'), { target: { value: 'hello' } });
+  
+        expect(dispatch).toBeCalledWith({
+          payload: {
+            page: 'entrance',
+            type: 'secretMessage',
+            value: 'hello',
+          },
+          type: 'application/changeInputFieldValue',
         });
       });
-      context('without secretMessage over 5 and under 21', () => {
-        beforeEach(() => {
-          inputFields.entrance.secretMessage.value = '';
-          useSelector.mockImplementation((selector) => selector({
-            entrance,
-            inputFields,
-          }));
+  
+      context('when clicks check postcard button', () => {
+        context('with secretMessage over 5 and under 21', () => {
+          beforeEach(() => {
+            inputFields.entrance.secretMessage.value = 'happy day!';
+  
+            useSelector.mockImplementation((selector) => selector({
+              entrance,
+              inputFields,
+            }));
+          });
+  
+          it('calls onHandleClickPostcard function', () => {
+            const { getByText } = entranceRender();
+            expect(getByText('엽서 확인하기')).not.toBeNull();
+  
+            fireEvent.click(getByText('엽서 확인하기'));
+  
+            // TODO: 공개 || 비공개일 경우 각각 다른 action들이 발생하는 것에 대한 테스트 코드를 작성 해야함.
+            // expect(dispatch).toBeCalledWith({
+            //   type: 'application/',
+            // });
+          });
         });
-
-        it('shows ErrorMessage', () => {
-          const { getByText } = entranceRender();
-          fireEvent.click(getByText('엽서 확인하기'));
-          expect(dispatch).toBeCalledWith({
-            type: 'application/setInputFieldsError',
-            payload: {
-              page: 'entrance',
-              type: 'secretMessage',
-              error: true,
-            },
+        context('without secretMessage over 5 and under 21', () => {
+          beforeEach(() => {
+            inputFields.entrance.secretMessage.value = '';
+            useSelector.mockImplementation((selector) => selector({
+              entrance,
+              inputFields,
+            }));
+          });
+  
+          it('shows ErrorMessage', () => {
+            const { getByText } = entranceRender();
+            fireEvent.click(getByText('엽서 확인하기'));
+            expect(dispatch).toBeCalledWith({
+              type: 'application/setInputFieldsError',
+              payload: {
+                page: 'entrance',
+                type: 'secretMessage',
+                error: true,
+              },
+            });
           });
         });
       });
     });
-  });
-
-  context('when postcard is not private', () => {
-    it('does not show secretMessage input', () => {
-      useSelector.mockImplementation((selector) => selector({
-        entrance: {
-          ...entrance,
-          isPrivate: false,
-        },
-        inputFields,
-      }));
-      const { queryByPlaceholderText } = entranceRender();
-
-      expect(queryByPlaceholderText('5 ~ 20자')).toBeNull();
-    });
-  });
-
-  context('when click check postcard button', () => {
-    context('with isPrivate is false', () => {
-      beforeEach(() => {
+  
+    context('when postcard is not private', () => {
+      it('does not show secretMessage input', () => {
         useSelector.mockImplementation((selector) => selector({
           entrance: {
             ...entrance,
@@ -142,70 +142,87 @@ describe('EntranceContainer', () => {
           },
           inputFields,
         }));
+        const { queryByPlaceholderText } = entranceRender();
+  
+        expect(queryByPlaceholderText('5 ~ 20자')).toBeNull();
       });
-
-      it("doesn't check secretMessage is valid", () => {
-        const { queryByText } = entranceRender();
-
-        fireEvent.click(queryByText('엽서 확인하기'));
-
-        expect(dispatch).not.toBeCalledWith({
-          type: 'application/setInputFieldsError',
-          payload: {
-            type: 'secretMessage',
-            error: true,
-          },
+    });
+  
+    context('when click check postcard button', () => {
+      context('with isPrivate is false', () => {
+        beforeEach(() => {
+          useSelector.mockImplementation((selector) => selector({
+            entrance: {
+              ...entrance,
+              isPrivate: false,
+            },
+            inputFields,
+          }));
+        });
+  
+        it("doesn't check secretMessage is valid", () => {
+          const { queryByText } = entranceRender();
+  
+          fireEvent.click(queryByText('엽서 확인하기'));
+  
+          expect(dispatch).not.toBeCalledWith({
+            type: 'application/setInputFieldsError',
+            payload: {
+              type: 'secretMessage',
+              error: true,
+            },
+          });
         });
       });
     });
-  });
-
-  context('when postcardCount is 0', () => {
-    beforeEach(() => {
-      useSelector.mockImplementation((selector) => selector({
-        entrance: {
-          ...entrance,
-          postcardCount: 0,
-        },
-        inputFields,
-      }));
+  
+    context('when postcardCount is 0', () => {
+      beforeEach(() => {
+        useSelector.mockImplementation((selector) => selector({
+          entrance: {
+            ...entrance,
+            postcardCount: 0,
+          },
+          inputFields,
+        }));
+      });
+  
+      it("doesn't show writing parts", () => {
+        const { getByText } = entranceRender();
+  
+        expect(getByText('해당 엽서로 작성할 수 있는 횟수가 없습니다.')).not.toBeNull();
+      });
     });
-
-    it("doesn't show writing parts", () => {
+    context('when postcardCount bigger than 0', () => {
+      beforeEach(() => {
+        useSelector.mockImplementation((selector) => selector({
+          entrance,
+          inputFields,
+        }));
+      });
+  
+      it('shows writing parts', () => {
+        const { getByText } = entranceRender();
+  
+        expect(getByText(`${sender}님으로 부터 받은 엽서로 ${postcardCount}번의 엽서를 작성하실 수 있어요 ! 코로나로 인해 만나보지 못한 소중한 사람에게 추억이 될 엽서를 작성해보세요 !`)).not.toBeNull();
+        expect(getByText('엽서 작성하기')).not.toBeNull();
+  
+        fireEvent.click(getByText('엽서 작성하기'));
+        expect(onHandleClickWritePostcard).toBeCalled();
+      });
+    });
+  
+    it('shows how many people write postcard', () => {
       const { getByText } = entranceRender();
-
-      expect(getByText('해당 엽서로 작성할 수 있는 횟수가 없습니다.')).not.toBeNull();
+  
+      expect(getByText(`현재 까지 ${writtenCount}명의 엽서가 작성 되었습니다.`)).not.toBeNull();
     });
-  });
-  context('when postcardCount bigger than 0', () => {
-    beforeEach(() => {
-      useSelector.mockImplementation((selector) => selector({
-        entrance,
-        inputFields,
-      }));
-    });
-
-    it('shows writing parts', () => {
+  
+    it("shows go to other postcard' and 'expire' button", () => {
       const { getByText } = entranceRender();
-
-      expect(getByText(`${sender}님으로 부터 받은 엽서로 ${postcardCount}번의 엽서를 작성하실 수 있어요 ! 코로나로 인해 만나보지 못한 소중한 사람에게 추억이 될 엽서를 작성해보세요 !`)).not.toBeNull();
-      expect(getByText('엽서 작성하기')).not.toBeNull();
-
-      fireEvent.click(getByText('엽서 작성하기'));
-      expect(onHandleClickWritePostcard).toBeCalled();
+  
+      expect(getByText('다른 사람 엽서 보러가기')).not.toBeNull();
+      expect(getByText('엽서 파기하기')).not.toBeNull();
     });
-  });
-
-  it('shows how many people write postcard', () => {
-    const { getByText } = entranceRender();
-
-    expect(getByText(`현재 까지 ${writtenCount}명의 엽서가 작성 되었습니다.`)).not.toBeNull();
-  });
-
-  it("shows go to other postcard' and 'expire' button", () => {
-    const { getByText } = entranceRender();
-
-    expect(getByText('다른 사람 엽서 보러가기')).not.toBeNull();
-    expect(getByText('엽서 파기하기')).not.toBeNull();
   });
 });

--- a/src/fixtures/entrance.js
+++ b/src/fixtures/entrance.js
@@ -3,6 +3,7 @@ const entrance = {
   isPrivate: true,
   postcardCount: 4,
   writtenCount: 1000,
+  movePage: false,
 };
 
 export default entrance;

--- a/src/page/EntrancePage.test.jsx
+++ b/src/page/EntrancePage.test.jsx
@@ -21,8 +21,13 @@ describe('EntrancePage', () => {
   const SENDER = entrance.sender;
 
   const dispatch = jest.fn();
+  
+  beforeEach(() => {
+    dispatch.mockClear();
+    mockPush.mockClear();
+    useDispatch.mockImplementation(() => dispatch);
+  });
 
-  useDispatch.mockImplementation(() => dispatch);
 
   function renderEntrance(location) {
     return render((
@@ -45,10 +50,7 @@ describe('EntrancePage', () => {
 
     expect(getByText(`${SENDER}님으로 부터 엽서가 도착했어요.`)).not.toBeNull();
 
-    fireEvent.click(getByText('엽서 확인하기'));
-
-    // TODO: 공개 || 비공개일 경우 각각 다른 action들이 발생하는 것에 대한 테스트 코드를 작성 해야함.
-    // expect(mockPush).toBeCalled();
+    expect(getByText('엽서 확인하기')).not.toBeNull();
 
     expect(getByText('다른 사람 엽서 보러가기')).not.toBeNull();
     expect(getByText('엽서 파기하기')).not.toBeNull();
@@ -83,6 +85,25 @@ describe('EntrancePage', () => {
       }));
 
       const { queryByText } = renderEntrance({ key: '발신자' });
+
+      expect(queryByText('엽서 작성하기')).toBeNull();
+    });
+  });
+
+  context('when pageMove is true', () => {
+    it('call history push with /postcard', () => {
+      useSelector.mockImplementation((selector) => selector({
+        entrance: {
+          ...entrance,
+          postcardCount: 0,
+          movePage: true,
+        },
+        inputFields,
+      }));
+
+      const { queryByText } = renderEntrance({ key: '발신자' });
+
+      expect(mockPush).toBeCalled();
 
       expect(queryByText('엽서 작성하기')).toBeNull();
     });

--- a/src/presentational/Postcard.jsx
+++ b/src/presentational/Postcard.jsx
@@ -28,7 +28,6 @@ export default function Postcard({
   showCompleteButton,
   onHandleCompleteClick,
 }) {
-  console.log(receiver,"============");
   return (
     <PostcardLayout
       type="button"

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -14,11 +14,7 @@ export async function postPostcard() {
   };
 }
 
-export async function postCheckValidPostcard() {
-  return {
-    success: true,
-  };
-}
+export const postCheckValidPostcard = jest.fn();
 
 export async function fetchPostcard() {
   return {

--- a/src/state/slice.js
+++ b/src/state/slice.js
@@ -76,9 +76,9 @@ const { actions, reducer } = createSlice({
       isPrivate: false,
       postcardCount: 5,
       writtenCount: 0,
+      movePage: false,
     },
     postcard,
-
   },
   reducers: {
     changeRadioChecked(state, { payload: value }) {
@@ -249,6 +249,15 @@ const { actions, reducer } = createSlice({
         },
       };
     },
+    admitPostcardAccess(state) {
+      return {
+        ...state,
+        entrance: {
+          ...state.entrance,
+          movePage: true,
+        },
+      };
+    },
   },
 });
 
@@ -265,6 +274,7 @@ export const {
   setWriteCompleteValues,
   resetPostcardInputFields,
   setPostcard,
+  admitPostcardAccess,
 } = actions;
 
 export function loadEntrance({ key }) {
@@ -302,15 +312,20 @@ export function sendPostcard({ postcardValues, onClickNext }) {
   };
 }
 
-export function checkValidPostcard({ key, secretMessage, onHandleClickPostcard }) {
-  return async () => {
+export function checkValidPostcard({ key, secretMessage, }) {
+  return async (dispatch) => {
     const data = await postCheckValidPostcard({ key, secretMessage });
 
-    const { success } = data;
-
-    if (success) {
+    if (data.success) {
       saveItem('secretMessage', secretMessage);
-      onHandleClickPostcard();
+      
+      dispatch(admitPostcardAccess());
+    } else {
+      dispatch(setInputFieldsError({
+        page: 'entrance',
+        type: 'secretMessage',
+        error: true,
+      }));
     }
   };
 }


### PR DESCRIPTION
- check movePage to use history.push on useEffect in EntranceContainer
- added movePage variable in entrance
- updated entrancePage testcode to use history.push when movePage is true
- changed mock api with jest.fn() to be changed in each test
- admitPostcardAccess to change movePage with true
- updated checkValidPostcard to call action not to handler
- when checkValidPostcard is failed, its call setInputFieldsError to show errorMessage in EntrancePage